### PR TITLE
Feature/pg 1043 hubspot private app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for considering contributing to go-hubspot.
 
 ## Reporting bug & Feature request
 
-If you've noticed a bug or have a feature request, please make an [issue](https://github.com/belong-inc/go-hubspot/issues).  
+If you've noticed a bug or have a feature request, please make an [issue](https://github.com/napptive/go-hubspot/issues).  
 Some issue contents are being or have been fixed, so it is recommended to check for similar issues.  
 
 ## Code change flow

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # go-hubspot
-[![godoc](https://godoc.org/github.com/belong-inc/go-hubspot?status.svg)](https://pkg.go.dev/github.com/belong-inc/go-hubspot)
+[![godoc](https://godoc.org/github.com/napptive/go-hubspot?status.svg)](https://pkg.go.dev/github.com/napptive/go-hubspot)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 HubSpot Go Library that works with [HubSpot API v3](https://developers.hubspot.com/docs/api/overview).  
@@ -11,7 +11,7 @@ production.
 # Install
 
 ```shell
-$ go get github.com/belong-inc/go-hubspot
+$ go get github.com/napptive/go-hubspot
 ```
 
 # Usage

--- a/auth.go
+++ b/auth.go
@@ -54,3 +54,22 @@ func (a *APIKey) SetAuthentication(r *http.Request) error {
 	r.URL.RawQuery = q.Encode()
 	return nil
 }
+
+type PrivateApp struct {
+	token string
+}
+
+func SetPriveApp(key string) AuthMethod {
+
+	return func(c *Client) {
+		c.authenticator = &PrivateApp{
+			token: key,
+		}
+	}
+}
+
+func (o *PrivateApp) SetAuthentication(r *http.Request) error {
+
+	r.Header.Set("Authorization", "Bearer "+o.token)
+	return nil
+}

--- a/contact_test.go
+++ b/contact_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestContactServiceOp_Create(t *testing.T) {

--- a/deal_test.go
+++ b/deal_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestDealServiceOp_Create(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	hubspot "github.com/belong-inc/go-hubspot"
+	hubspot "github.com/napptive/go-hubspot"
 )
 
 type ExampleContact struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/belong-inc/go-hubspot
+module github.com/napptive/go-hubspot
 
-go 1.14
+go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.4

--- a/gohubspot_test.go
+++ b/gohubspot_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	hubspot "github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	hubspot "github.com/napptive/go-hubspot"
 )
 
 var (

--- a/marketing_email.go
+++ b/marketing_email.go
@@ -3,7 +3,7 @@ package hubspot
 import (
 	"fmt"
 
-	"github.com/belong-inc/go-hubspot/legacy"
+	"github.com/napptive/go-hubspot/legacy"
 )
 
 const (

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestOAuthTokenManager_RetrieveToken(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestWithAPIVersion(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -3,8 +3,8 @@ package hubspot_test
 import (
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestRequestQueryOption_setupProperties(t *testing.T) {

--- a/type_test.go
+++ b/type_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+	"github.com/napptive/go-hubspot"
 )
 
 func TestHsStr_String(t *testing.T) {


### PR DESCRIPTION
## What to do  
Add a new auth method to use in the private apps

## Background  
HubSpot has deprecated [APIKey authentication](https://developers.hubspot.com/changelog/upcoming-api-key-sunset?utm_campaign=customer-marketing&utm_medium=email&utm_content=226546091&utm_source=hs_automation)

## Acceptance criteria  